### PR TITLE
Add links to individual perf commands in Main Page (index.md)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,12 +15,12 @@ Tracepoints are instrumentation points placed at logical locations in code, such
 
 The userspace `perf` command present a simple to use interface with commands like:
 
-- `perf stat`: obtain event counts
-- `perf record`: record events for later reporting
-- `perf report`: break down events by process, function, etc.
-- `perf annotate`: annotate assembly or source code with event counts
-- `perf top`: see live event count 
-- `perf bench`: run different kernel microbenchmarks
+- [`perf stat`](/tutorial/#counting-with-perf-stat): obtain event counts
+- [`perf record`](/tutorial/#sampling-with-perf-record): record events for later reporting
+- [`perf report`](/tutorial/#sampling-with-perf-record): break down events by process, function, etc.
+- [`perf annotate`](/tutorial/#sample-analysis-with-perf-report): annotate assembly or source code with event counts
+- [`perf top`](/tutorial/#live-analysis-with-perf-top): see live event count 
+- [`perf bench`](/tutorial/#benchmarking-with-perf-bench): run different kernel microbenchmarks
 
 To learn more, see the examples in the [Tutorial](./tutorial.md) or how to do a [Top-Down Analysis](./top-down-analysis.md).
 


### PR DESCRIPTION
Before, you can't go from main page to individual perf commands, which is supported in the old perf wiki.

<img width="566" alt="image" src="https://github.com/user-attachments/assets/f38c2441-02f4-4cb2-b2d6-b46d724d807f">

(This is the old perfwiki)
<img width="462" alt="image" src="https://github.com/user-attachments/assets/4245cb57-a621-4198-b2af-21fcc4dc027f">

I added this feature to the new perf wiki.

<img width="563" alt="image" src="https://github.com/user-attachments/assets/7eb2f42e-d615-4234-bcd8-0188e2cacd3b">

Thanks,
Howard


