### PR TITLE
Fix display issue of the 404 page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: "perf: Linux profiling with performance counters"
+site_url: https://perfwiki.github.io/main/
 repo_url: https://github.com/perfwiki/main
 edit_uri: ../main/edit/main/docs
 nav:


### PR DESCRIPTION
As reported by Adrian Hunter, perf wiki renders the 404 page (page not found) incorrectly. Link:
https://lore.kernel.org/linux-perf-users/533a9e5e-b320-41d6-8d8a-223f69d719f5@intel.com/

<img width="1469" alt="Screenshot 2024-11-30 at 9 08 18 AM" src="https://github.com/user-attachments/assets/51420dc8-629c-47c0-9ade-6ca012b369d2">

This fixes this rendering issue by adding a site_url attribute, it is tested on my own github perfwiki page, url:
https://sberm.github.io/perfwiki/.

I will not add a 'Fixes:' because this bug has existed since the very first commit.

Reported-by: Adrian Hunter <adrian.hunter@intel.com>