### PR TITLE
docs: fix development page markdown formatting

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -4,46 +4,52 @@
 
 ## Installation Guide
 
-You'll need to install `perf` in your system. `perf` uses CPU performance counters( Performance Monitoring Counters or PMCs). 
+You'll need to install `perf` in your system. `perf` uses CPU performance counters (Performance Monitoring Counters or PMCs).
 
-1) Install Required Packages like *libelf-dev* *libdw-dev* *binutils-dev*  
-*libaudit-dev* by using the following command 
-```sh
- sudo apt-get install build-essential libelf-dev libdw-dev binutils-dev 
- libaudit-dev libtraceevent-dev systemtap-sdt-dev libunwind-dev libslang2-dev libperl-dev libzstd-dev libbabeltrace-ctf-dev flex bison 
-```
+1. Install Required Packages like *libelf-dev* *libdw-dev* *binutils-dev*
+   *libaudit-dev* by using the following command
 
-2) Download the Source code for perf-tools v6.3 using the following command
-```sh
- git clone https://git.kernel.org/pub/scm/linux/kernel/git/perf/perf-tools-next.git/
-```
-
-3) Install `perf`. `perf` command is available in packages *linux-tools-common*, *linux-intel-iotg-tools-common*, etc. Hence, install any of these. 
-
-4) Run `make` command to build the project
-
-    - 4.1) It may show an error since the config file is not set and has to be changed. Run the following command.
- `make xconfig` 
-
-    - 4.2) We will also need to install qt5 for this. 
-    Install it using `sudo apt-get install qtbase5-dev` OR `sudo apt install qt5*` and set the path using 
     ```sh
-    export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
+    sudo apt-get install build-essential libelf-dev libdw-dev binutils-dev \
+    libaudit-dev libtraceevent-dev systemtap-sdt-dev libunwind-dev libslang2-dev libperl-dev libzstd-dev libbabeltrace-ctf-dev flex bison
     ```
 
-    - 4.3) Check if qt5 has been installed properly using *qmake --version* 
+2. Download the latest perf-tools Source code using the following command
 
-    - 4.4) You might need to set `kernel.perf_event_paranoid = -1` because the `perf record` command may fail due to restricted access to performance monitoring features on your system.
     ```sh
-    sudo sysctl -w kernel.perf_event_paranoid=-1
+    git clone https://git.kernel.org/pub/scm/linux/kernel/git/perf/perf-tools-next.git/
     ```
 
-    Note: this should not be done in production environment
+3. Install `perf`. `perf` command is available in packages *linux-tools-common*, *linux-intel-iotg-tools-common*, etc. Hence, install any of these.
 
-    - 4.4) Now, Finally run *make xconfig* and it will work properly.
+4. Run `make` command to build the project
 
-5) Go to the root directory of the kernel and run `perf test`. You will see tests 
-passing, skipping, or failing.
+    1. It may show an error since the config file is not set and has to be changed. Run the following command.
+
+        ```sh
+        make xconfig
+        ```
+
+    2. We will also need to install qt5 for this. Install it using `sudo apt-get install qtbase5-dev` OR `sudo apt install qt5*` and set the path using
+
+        ```sh
+        export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
+        ```
+
+    3. Check if qt5 has been installed properly using *qmake --version*
+
+    4. You might need to set `kernel.perf_event_paranoid = -1` because the `perf record` command may fail due to restricted access to performance monitoring features on your system.
+
+        ```sh
+        sudo sysctl -w kernel.perf_event_paranoid=-1
+        ```
+
+        Note: this should not be done in production environment
+
+    5. Now, Finally run *make xconfig* and it will work properly.
+
+5. Go to the root directory of the kernel and run `perf test`. You will see tests
+   passing, skipping, or failing.
 
 ## Maintainer Trees
 


### PR DESCRIPTION
This PR fixes the messed-up rendering issue on Development page where installation steps and shell code blocks were displayed incorrectly.

**Before:**
<img width="799" height="838" alt="image" src="https://github.com/user-attachments/assets/ae6ab585-9fb0-4790-aee2-aea8fc1760c2" />

**After:**
<img width="785" height="879" alt="image" src="https://github.com/user-attachments/assets/52b64661-a6c6-4d27-b66b-657a5a07e26b" />

---
Note that this PR also changes `v6.3` to `latest`, since v6.3 is no longer the latest version, with a little typo fix.