### PR TITLE
ci: fix GitLab Pages build workflow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,12 +1,16 @@
+image: python:3.14
+stages:
+  - deploy
 pages:
   stage: deploy
-  image: python:latest
+  variables:
+    # https://timvink.github.io/mkdocs-git-revision-date-localized-plugin/#:~:text=(docs)-,Gitlab%20Runners,-%3A%20set%
+    GIT_DEPTH: "0"
   script:
-    - pip install mkdocs-material
+    - python -m pip install mkdocs-material mkdocs-git-revision-date-localized-plugin
     - mkdocs build --site-dir public
   artifacts:
     paths:
       - public
   rules:
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
 pages:
   stage: deploy
   variables:
-    # https://timvink.github.io/mkdocs-git-revision-date-localized-plugin/#:~:text=(docs)-,Gitlab%20Runners,-%3A%20set%
+    # https://timvink.github.io/mkdocs-git-revision-date-localized-plugin/#:~:text=Gitlab%20Runners
     GIT_DEPTH: "0"
   script:
     - python -m pip install mkdocs-material mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION
Implement GitLab Pages support.

Close: https://github.com/perfwiki/main/issues/3

---
Note: Use following configuration in `mkdocs.yml` will help support deployment to both GitHub Pages and GitLab Pages.
```
site_url: !ENV [MKDOCS_SITE_URL, "https://perfwiki.github.io/main/"]
```

<img width="740" height="514" alt="image" src="https://github.com/user-attachments/assets/a436ce1e-42b4-4554-8fb4-076a932540b6" />


