### PR TITLE
docs: fix "Man Pages" branch reference + add missing extension

### DIFF
--- a/docs/man-pages.md
+++ b/docs/man-pages.md
@@ -49,7 +49,7 @@ These are the links to the `man-pages` for the `perf` tool:
 
 The latest source is available in the
 [perf-tools-next](https://git.kernel.org/pub/scm/linux/kernel/git/perf/perf-tools-next.git/tree/tools/perf/Documentation?h=perf-tools-next)
-tree under `tools/perf/Documents`.
+tree under `tools/perf/Documentation`.
 
 - [perf](https://git.kernel.org/pub/scm/linux/kernel/git/perf/perf-tools-next.git/tree/tools/perf/Documentation/perf.txt?h=perf-tools-next)
 - [perf annotate](https://git.kernel.org/pub/scm/linux/kernel/git/perf/perf-tools-next.git/tree/tools/perf/Documentation/perf-annotate.txt?h=perf-tools-next)
@@ -119,4 +119,4 @@ tree under `tools/perf/Documents`.
 
 ## Kernel Version
 
-This page links the each document to the [`linux-next` kernel branch](https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git).
+This page links the each document to the [`perf-tools-next`](https://git.kernel.org/pub/scm/linux/kernel/git/perf/perf-tools-next.git) branch of the perf tools tree.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ markdown_extensions:
   - admonition
   - footnotes
   - meta
+  - pymdownx.superfences
   - toc:
       permalink: true
 


### PR DESCRIPTION
This PR updates "Man Pages" page description to make links point to the `perf-tools-next` tree instead of old `linux-next` kernel branch, and also fix wrong path.

And my apologies. In https://github.com/perfwiki/main/pull/19, I forgot to add the extension, so code blocks with language specifiers like ` ```sh ` may fail to be read correctly.
